### PR TITLE
CDD-1537: ApiSubscriptionFieldsConnector and CustomsNotificationConne…

### DIFF
--- a/app/uk/gov/hmrc/customs/declaration/config/CustomsDeclarationsModule.scala
+++ b/app/uk/gov/hmrc/customs/declaration/config/CustomsDeclarationsModule.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.customs.declaration.config
 
 import com.google.inject.AbstractModule
-import uk.gov.hmrc.customs.declaration.services.CustomsConfigService
+import uk.gov.hmrc.customs.declaration.services.DeclarationsConfigService
 
 class CustomsDeclarationsModule extends AbstractModule {
   def configure() {
     // asEagerSingleton forces evaluation at application startup time
-    bind(classOf[CustomsConfigService]).asEagerSingleton()
+    bind(classOf[DeclarationsConfigService]).asEagerSingleton()
   }
 }

--- a/app/uk/gov/hmrc/customs/declaration/connectors/ApiSubscriptionFieldsConnector.scala
+++ b/app/uk/gov/hmrc/customs/declaration/connectors/ApiSubscriptionFieldsConnector.scala
@@ -17,10 +17,11 @@
 package uk.gov.hmrc.customs.declaration.connectors
 
 import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.customs.api.common.config.ServicesConfig
+
 import uk.gov.hmrc.customs.declaration.logging.DeclarationsLogger
-import uk.gov.hmrc.customs.declaration.model.actionbuilders.{GenericValidatedPayloadRequest, ValidatedPayloadRequest}
+import uk.gov.hmrc.customs.declaration.model.actionbuilders.GenericValidatedPayloadRequest
 import uk.gov.hmrc.customs.declaration.model.{ApiSubscriptionFieldsResponse, ApiSubscriptionKey}
+import uk.gov.hmrc.customs.declaration.services.DeclarationsConfigService
 import uk.gov.hmrc.http.{HeaderCarrier, HttpException}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
@@ -31,15 +32,10 @@ import scala.concurrent.Future
 @Singleton
 class ApiSubscriptionFieldsConnector @Inject()(http: HttpClient,
                                                logger: DeclarationsLogger,
-                                               servicesConfig: ServicesConfig) {
-
-  private val service = "api-subscription-fields"
-  private val serviceContext = service + ".context"
-  private lazy val baseUrl = servicesConfig.baseUrl(service)
-  private lazy val context = servicesConfig.getConfString(serviceContext, throw new IllegalStateException(s"Configuration error - $serviceContext not found."))
+                                               config: DeclarationsConfigService) {
 
   def getSubscriptionFields[A](apiSubsKey: ApiSubscriptionKey)(implicit vpr: GenericValidatedPayloadRequest[A], hc: HeaderCarrier): Future[ApiSubscriptionFieldsResponse] = {
-    val url = ApiSubscriptionFieldsPath.url(s"$baseUrl$context", apiSubsKey)
+    val url = ApiSubscriptionFieldsPath.url(config.apiSubscriptionFieldsBaseUrl, apiSubsKey)
     get(url)
   }
 

--- a/app/uk/gov/hmrc/customs/declaration/controllers/DeclarationsDocumentationController.scala
+++ b/app/uk/gov/hmrc/customs/declaration/controllers/DeclarationsDocumentationController.scala
@@ -26,8 +26,7 @@ import uk.gov.hmrc.customs.api.common.controllers.DocumentationController
 @Singleton
 class DeclarationsDocumentationController @Inject()(httpErrorHandler: HttpErrorHandler, configuration: Configuration) extends DocumentationController(httpErrorHandler) {
 
-  private val apiScopeConfigKey = "customs.definition.api-scope"
-  private lazy val apiScopeKey = configuration.getString(apiScopeConfigKey).getOrElse(throw new IllegalStateException(s"$apiScopeConfigKey is not configured"))
+  private lazy val apiScopeKey = "write:customs-declaration"
   private lazy val whitelistedApplicationIds = configuration.getStringSeq("api.access.version-2.0.whitelistedApplicationIds").getOrElse(Seq.empty)
   private lazy val version2EndpointsEnabled = configuration.getBoolean("api.access.version-2.0.enabled").getOrElse(true)
 

--- a/app/uk/gov/hmrc/customs/declaration/model/DeclarationsConfig.scala
+++ b/app/uk/gov/hmrc/customs/declaration/model/DeclarationsConfig.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.customs.declaration.model
 
-case class ApiDefinitionConfig(apiScope: String)
-
-case class CustomsEnrolmentConfig(customsEnrolmentName: String, eoriIdentifierName: String)
+trait DeclarationsConfig {
+  val apiSubscriptionFieldsBaseUrl: String
+  val customsNotificationBaseBaseUrl: String
+  val customsNotificationBearerToken: String
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,11 +25,6 @@ application.logger.name = ${appName}
 httpHeadersWhitelist += "api-subscription-fields-id"
 httpHeadersWhitelist += "X-Client-ID"
 
-customs.definition.api-scope = "write:customs-declaration"
-
-customs.enrolment.name = "HMRC-CUS-ORG"
-customs.enrolment.eori-identifier = "EORINumber"
-
 xsd.locations.submit += "/api/conf/2.0/schemas/wco/declaration/DocumentMetaData_2_DMS.xsd"
 xsd.locations.submit += "/api/conf/2.0/schemas/wco/declaration/WCO_DEC_2_DMS.xsd"
 


### PR DESCRIPTION
…ctor in customs-declaration should use fail fast config service. Also removed unused config for:

- customs.definition.api-scope
- customs.enrolment.name
- customs.enrolment.eori-identifier