### PR TITLE
CDD-2679_Do_we_enforce_UTF-8_Tests

### DIFF
--- a/app/uk/gov/hmrc/customs/declaration/connectors/declarationConnectors.scala
+++ b/app/uk/gov/hmrc/customs/declaration/connectors/declarationConnectors.scala
@@ -95,7 +95,7 @@ trait MdgDeclarationConnector extends DeclarationsCircuitBreaker {
   }
 
   private def post[A](xml: NodeSeq, url: String)(implicit vpr: ValidatedPayloadRequest[A], hc: HeaderCarrier) = {
-    logger.debug(s"Sending request to $url. Payload:\n${new PrettyPrinter(120, 2).format(xml.head, TopScope)}")
+    logger.debug(s"Sending request to $url.\n Headers:\n ${hc}\n Payload:\n${new PrettyPrinter(120, 2).format(xml.head, TopScope)}")
 
     http.POSTString[HttpResponse](url, xml.toString())
       .recoverWith {

--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ val compileDependencies = Seq(customsApiCommon, circuitBreaker, simpleReactiveMo
 val testDependencies = Seq(hmrcTest, scalaTestPlusPlay, wireMock, mockito, customsApiCommonTests, reactiveMongoTest)
 
 unmanagedResourceDirectories in Compile += baseDirectory.value / "public"
+unmanagedResourceDirectories in ComponentTest += baseDirectory.value / "test" / "resources"
 (managedClasspath in Runtime) += (packageBin in Assets).value
 
 libraryDependencies ++= compileDependencies ++ testDependencies

--- a/test/component/Utf8Spec.scala
+++ b/test/component/Utf8Spec.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, OptionValues}
+import play.api.mvc._
+import play.api.test.Helpers.{status, _}
+import uk.gov.hmrc.customs.declaration.model.{ApiSubscriptionKey, VersionOne, VersionTwo}
+import util.AuditService
+import util.FakeRequests._
+import util.RequestHeaders.ValidHeadersV2WithCharset
+import util.TestXMLData.InvalidRawXmlByte
+import util.externalservices._
+
+import scala.concurrent.Future
+
+class Utf8Spec extends ComponentTestSpec with AuditService with ExpectedTestResponses
+  with Matchers
+  with OptionValues
+  with BeforeAndAfterAll
+  with BeforeAndAfterEach
+  with MdgWcoDecService
+  with ApiSubscriptionFieldsService
+  with AuthService
+  with CustomsDeclarationsMetricsService
+  with NrsService {
+
+  private val endpoint = "/"
+
+  private val apiSubscriptionKeyForXClientIdV1 =
+    ApiSubscriptionKey(clientId = clientId, context = "customs%2Fdeclarations", version = VersionOne)
+
+  private val apiSubscriptionKeyForXClientIdV2 = apiSubscriptionKeyForXClientIdV1.copy(version = VersionTwo)
+
+  override protected def beforeAll() {
+    startMockServer()
+  }
+
+  override protected def beforeEach() {
+    resetMockServer()
+  }
+
+  override protected def afterAll() {
+    stopMockServer()
+  }
+
+  feature("Declaration API rejects declaration payloads containing invalid utf-8 bytes") {
+    scenario(
+      "Response status 200 when user submits a valid utf-8 encoded payload with Header 'Content Type: application/xml'"
+    ) {
+      Given("the API is available")
+
+      startMdgWcoDecServiceV2()
+      startApiSubscriptionFieldsService(apiSubscriptionKeyForXClientIdV2)
+
+      val request = ValidSubmissionRawRequest.fromCsp
+        .withMethod(POST)
+        .withTarget(ValidSubmissionRawRequest.target.withPath(endpoint))
+
+      And("the CSP is authorised with its privileged application")
+      authServiceAuthorizesCSP()
+
+      When("a POST request with data is sent to the API")
+      val result: Future[Result] = route(app = app, request).value
+
+      Then("a response with a 400 (BAD_REQUEST) status is received")
+      status(result) shouldBe ACCEPTED
+    }
+
+    scenario(
+      "Response status 400 when user submits a payload containing a non-utf-8 byte with Header 'Content Type: application/xml'"
+    ) {
+      Given("the API is available")
+
+      startMdgWcoDecServiceV2()
+      startApiSubscriptionFieldsService(apiSubscriptionKeyForXClientIdV2)
+
+      val request = ValidSubmissionRawRequest.fromCsp
+        .withMethod(POST)
+        .withTarget(ValidSubmissionRawRequest.target.withPath(endpoint))
+        .withRawBody(InvalidRawXmlByte)
+
+      And("the CSP is authorised with its privileged application")
+      authServiceAuthorizesCSP()
+
+      When("a POST request with data is sent to the API")
+      val result: Future[Result] = route(app = app, request).value
+
+      Then("a response with a 400 (BAD_REQUEST) status is received")
+      status(result) shouldBe BAD_REQUEST
+    }
+
+    scenario(
+      "Response status 200 when user submits a valid utf-8 encoded payload with Header 'Content Type: application/xml; charset=UTF-8'"
+    ) {
+      Given("the API is available")
+
+      startMdgWcoDecServiceV2()
+      startApiSubscriptionFieldsService(apiSubscriptionKeyForXClientIdV2)
+
+      val request = ValidSubmissionRawRequest.fromCsp
+        .withMethod(POST)
+        .withHeaders(ValidHeadersV2WithCharset.toSeq: _*)
+        .withTarget(ValidSubmissionRawRequest.target.withPath(endpoint))
+
+      And("the CSP is authorised with its privileged application")
+      authServiceAuthorizesCSP()
+
+      When("a POST request with data is sent to the API")
+      val result: Future[Result] = route(app = app, request).value
+
+      Then("a response with a 202 (ACCEPTED) status is received")
+      status(result) shouldBe ACCEPTED
+    }
+
+    scenario(
+      "Response status 400 when user submits a payload containing a non-utf-8 byte with Header 'Content Type: application/xml; charset=UTF-8'"
+    ) {
+      Given("the API is available")
+
+      startMdgWcoDecServiceV2()
+      startApiSubscriptionFieldsService(apiSubscriptionKeyForXClientIdV2)
+
+      val request = ValidSubmissionRawRequest.fromCsp
+        .withMethod(POST)
+        .withHeaders(ValidHeadersV2WithCharset.toSeq: _*)
+        .withTarget(ValidSubmissionRawRequest.target.withPath(endpoint))
+        .withRawBody(InvalidRawXmlByte)
+
+      And("the CSP is authorised with its privileged application")
+      authServiceAuthorizesCSP()
+
+      When("a POST request with data is sent to the API")
+      val result: Future[Result] = route(app = app, request).value
+
+      Then("a response with a 400 (BAD_REQUEST) status is received")
+      status(result) shouldBe BAD_REQUEST
+    }
+  }
+}

--- a/test/resources/raw/invalid_xml.raw
+++ b/test/resources/raw/invalid_xml.raw
@@ -1,0 +1,212 @@
+<md:MetaData xmlns:md="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2" xmlns="urn:wco:datamodel:WCO:DEC-DMS:2"
+                 xmlns:udt="urn:wco:datamodel:WCO:Declaration_DS:DMS:2">
+  <md:WCODataModelVersionCode>3.6</md:WCODataModelVersionCode>
+  <md:WCOTypeName>DEC-DMS</md:WCOTypeName>
+  <md:ResponsibleCountryCode>GB</md:ResponsibleCountryCode>
+  <md:ResponsibleAgencyName>Agency ABC</md:ResponsibleAgencyName>
+  <md:AgencyAssignedCustomizationVersionCode>v1.2</md:AgencyAssignedCustomizationVersionCode>
+  <Declaration>
+    <AcceptanceDateTime>
+      <udt:DateTimeString formatCode="304">20161207010101Z</udt:DateTimeString>
+    </AcceptanceDateTime>
+    <FunctionCode>9</FunctionCode>
+    <FunctionalReferenceID>DemoUK20161207_010</FunctionalReferenceID>
+    <TypeCode>IMZ</TypeCode>
+    <DeclarationOfficeID>0051</DeclarationOfficeID>
+    <TotalPackageQuantity>1</TotalPackageQuantity>
+    <Agent>
+      <ID>ZZ123456789001</ID>
+      <FunctionCode>2</FunctionCode>
+    </Agent>
+    <CurrencyExchange> <!-- 1094 new section-->
+      <RateNumeric>1.234</RateNumeric>
+    </CurrencyExchange>
+    <Declarant>
+      <ID>ZZ123456789000</ID>
+    </Declarant>
+    <GoodsShipment>
+      <ExitDateTime>
+        <udt:DateTimeString formatCode="304">20161207010101Z</udt:DateTimeString>
+      </ExitDateTime> <!-- 1094 -->
+      <TransactionNatureCode>1</TransactionNatureCode>
+      <Buyer>
+        <Name>Buyer¡Äame Part1Buyername Part2</Name>
+        <Address>
+          <CityName>Buyer City name</CityName>
+          <CountryCode>NL</CountryCode>
+          <Line>Buyerstreet Part1BuyerStreet Part2 7C</Line>
+          <PostcodeID>8603 AV</PostcodeID>
+        </Address>
+      </Buyer>
+      <Consignee>
+        <ID>ZZ123456789002</ID>
+      </Consignee>
+      <Consignment>
+        <ArrivalTransportMeans>
+          <Name>Titanic II</Name>
+          <TypeCode>1</TypeCode>
+        </ArrivalTransportMeans>
+        <GoodsLocation>
+          <Name>3016 DR, Loods 5</Name>
+        </GoodsLocation>
+        <LoadingLocation>  <!-- 1094 -->
+          <Name>Neverland</Name>
+          <ID>1234</ID>
+        </LoadingLocation>
+        <TransportEquipment>
+          <SequenceNumeric>1</SequenceNumeric>
+          <ID>CONTAINERNUMBER17</ID>
+        </TransportEquipment>
+        <TransportEquipment>
+          <SequenceNumeric>2</SequenceNumeric>
+          <ID>CONTAINERNUMBER22</ID>
+        </TransportEquipment>
+      </Consignment>
+      <DomesticDutyTaxParty>
+        <ID>ZZ123456789003</ID>
+      </DomesticDutyTaxParty>
+      <ExportCountry>
+        <ID>CA</ID>
+      </ExportCountry>
+      <GovernmentAgencyGoodsItem>
+        <SequenceNumeric>1</SequenceNumeric>
+        <StatisticalValueAmount>1234567</StatisticalValueAmount>
+        <AdditionalDocument>
+          <CategoryCode>I</CategoryCode>
+          <EffectiveDateTime>
+            <udt:DateTimeString formatCode="304">20130812091112Z</udt:DateTimeString>
+          </EffectiveDateTime> <!-- 1094 -->
+          <ID>I003INVOERVERGEU</ID> <!-- CDD-1094 an..70 -->
+          <Name>NAME_HERE</Name> <!-- CDD-1094 ADDED -->
+          <TypeCode>003</TypeCode>
+          <LPCOExemptionCode>123</LPCOExemptionCode> <!-- 1094 -->
+        </AdditionalDocument>
+        <AdditionalDocument>
+          <CategoryCode>N</CategoryCode>
+          <ID>N861UnivCertOrigin</ID>
+          <TypeCode>861</TypeCode>
+        </AdditionalDocument>
+        <AdditionalInformation>
+          <StatementCode>1</StatementCode><!-- not affiliated -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>3</StatementCode><!-- no price influence -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>5</StatementCode><!-- no approximate value -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>8</StatementCode><!-- special restrictions -->
+          <StatementDescription>Special Restrictions</StatementDescription>
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>9</StatementCode><!-- no price conditions -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>11</StatementCode><!-- no royalties or license fees -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>13</StatementCode><!-- no other revenue -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>16</StatementCode><!-- customs decisions -->
+          <StatementDescription>11NL12345678901234</StatementDescription>
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>17</StatementCode><!-- contract information -->
+          <StatementDescription>Contract 12123, 24-11-2011</StatementDescription>
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>90010</StatementCode>
+          <StatementDescription>VERVOERDER: InterTrans</StatementDescription>
+          <StatementTypeCode>CUS</StatementTypeCode>
+        </AdditionalInformation>
+        <Commodity>
+          <Description>Inertial navigation systems</Description>
+          <Classification>
+            <ID>901420209000000000</ID>
+            <IdentificationTypeCode>SRZ</IdentificationTypeCode>
+          </Classification>
+          <Classification>
+            <ID>9002</ID>
+            <IdentificationTypeCode>GN</IdentificationTypeCode><!--Not representative for this commodity-->
+          </Classification>
+          <DutyTaxFee>
+            <AdValoremTaxBaseAmount currencyID="EUR">900</AdValoremTaxBaseAmount>
+            <DutyRegimeCode>
+              100<!--Specified a Tariff Quota preference (not representative)--></DutyRegimeCode>
+            <TypeCode>B00</TypeCode>
+            <Payment>
+              <MethodCode>M</MethodCode>
+            </Payment>
+          </DutyTaxFee>
+        </Commodity>
+        <GovernmentProcedure>
+          <CurrentCode>40</CurrentCode>
+          <PreviousCode>91</PreviousCode>
+        </GovernmentProcedure>
+        <GovernmentProcedure>
+          <CurrentCode>C30</CurrentCode>
+        </GovernmentProcedure>
+        <Origin>
+          <CountryCode>US</CountryCode>
+        </Origin>
+        <Packaging>
+          <SequenceNumeric>1</SequenceNumeric>
+          <MarksNumbersID>SHIPPING MARKS PART1 SHIPPING</MarksNumbersID>
+          <QuantityQuantity>9</QuantityQuantity>
+          <TypeCode>CT</TypeCode>
+        </Packaging>
+        <PreviousDocument>
+          <ID>X355ID13</ID> <!-- 1094 -->
+          <LineNumeric>1</LineNumeric>
+        </PreviousDocument>
+        <ValuationAdjustment>
+          <AdditionCode>155</AdditionCode>
+        </ValuationAdjustment>
+      </GovernmentAgencyGoodsItem>
+      <Invoice>
+        <ID>INVOICENUMBER</ID>
+        <IssueDateTime>
+          <udt:DateTimeString formatCode="304">20130812091112Z</udt:DateTimeString>
+        </IssueDateTime>    <!-- 1094 -->
+      </Invoice>
+      <Payer>
+        <ID>ZZ123456789003</ID>
+      </Payer>
+      <Seller>
+        <Name>Seller name Part1Sellername Part2</Name>
+        <Address>
+          <CityName>Seller City name</CityName>
+          <CountryCode>MX</CountryCode>
+          <Line>Sellerstreet Part1SellerStreet Part2 7C</Line>
+          <PostcodeID>8603 AV</PostcodeID>
+        </Address>
+      </Seller>
+      <Surety>
+        <ID>ZZ123456789003</ID>
+      </Surety>
+      <TradeTerms>
+        <ConditionCode>CIP</ConditionCode>
+        <CountryRelationshipCode>158</CountryRelationshipCode>
+        <LocationName>Rotterdam</LocationName>
+      </TradeTerms>
+      <UCR>
+        <ID>UN1234567893123456789</ID>
+        <TraderAssignedReferenceID>P198R65Q29</TraderAssignedReferenceID>
+      </UCR>
+      <Warehouse>
+        <ID>A123456ZZ</ID>
+      </Warehouse>
+    </GoodsShipment>
+  </Declaration>
+</md:MetaData>

--- a/test/resources/raw/valid_xml.raw
+++ b/test/resources/raw/valid_xml.raw
@@ -1,0 +1,212 @@
+<md:MetaData xmlns:md="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2" xmlns="urn:wco:datamodel:WCO:DEC-DMS:2"
+                 xmlns:udt="urn:wco:datamodel:WCO:Declaration_DS:DMS:2">
+  <md:WCODataModelVersionCode>3.6</md:WCODataModelVersionCode>
+  <md:WCOTypeName>DEC-DMS</md:WCOTypeName>
+  <md:ResponsibleCountryCode>GB</md:ResponsibleCountryCode>
+  <md:ResponsibleAgencyName>Agency ABC</md:ResponsibleAgencyName>
+  <md:AgencyAssignedCustomizationVersionCode>v1.2</md:AgencyAssignedCustomizationVersionCode>
+  <Declaration>
+    <AcceptanceDateTime>
+      <udt:DateTimeString formatCode="304">20161207010101Z</udt:DateTimeString>
+    </AcceptanceDateTime>
+    <FunctionCode>9</FunctionCode>
+    <FunctionalReferenceID>DemoUK20161207_010</FunctionalReferenceID>
+    <TypeCode>IMZ</TypeCode>
+    <DeclarationOfficeID>0051</DeclarationOfficeID>
+    <TotalPackageQuantity>1</TotalPackageQuantity>
+    <Agent>
+      <ID>ZZ123456789001</ID>
+      <FunctionCode>2</FunctionCode>
+    </Agent>
+    <CurrencyExchange> <!-- 1094 new section-->
+      <RateNumeric>1.234</RateNumeric>
+    </CurrencyExchange>
+    <Declarant>
+      <ID>ZZ123456789000</ID>
+    </Declarant>
+    <GoodsShipment>
+      <ExitDateTime>
+        <udt:DateTimeString formatCode="304">20161207010101Z</udt:DateTimeString>
+      </ExitDateTime> <!-- 1094 -->
+      <TransactionNatureCode>1</TransactionNatureCode>
+      <Buyer>
+        <Name>Buyer name Part1Buyername Part2</Name>
+        <Address>
+          <CityName>Buyer City name</CityName>
+          <CountryCode>NL</CountryCode>
+          <Line>Buyerstreet Part1BuyerStreet Part2 7C</Line>
+          <PostcodeID>8603 AV</PostcodeID>
+        </Address>
+      </Buyer>
+      <Consignee>
+        <ID>ZZ123456789002</ID>
+      </Consignee>
+      <Consignment>
+        <ArrivalTransportMeans>
+          <Name>Titanic II</Name>
+          <TypeCode>1</TypeCode>
+        </ArrivalTransportMeans>
+        <GoodsLocation>
+          <Name>3016 DR, Loods 5</Name>
+        </GoodsLocation>
+        <LoadingLocation>  <!-- 1094 -->
+          <Name>Neverland</Name>
+          <ID>1234</ID>
+        </LoadingLocation>
+        <TransportEquipment>
+          <SequenceNumeric>1</SequenceNumeric>
+          <ID>CONTAINERNUMBER17</ID>
+        </TransportEquipment>
+        <TransportEquipment>
+          <SequenceNumeric>2</SequenceNumeric>
+          <ID>CONTAINERNUMBER22</ID>
+        </TransportEquipment>
+      </Consignment>
+      <DomesticDutyTaxParty>
+        <ID>ZZ123456789003</ID>
+      </DomesticDutyTaxParty>
+      <ExportCountry>
+        <ID>CA</ID>
+      </ExportCountry>
+      <GovernmentAgencyGoodsItem>
+        <SequenceNumeric>1</SequenceNumeric>
+        <StatisticalValueAmount>1234567</StatisticalValueAmount>
+        <AdditionalDocument>
+          <CategoryCode>I</CategoryCode>
+          <EffectiveDateTime>
+            <udt:DateTimeString formatCode="304">20130812091112Z</udt:DateTimeString>
+          </EffectiveDateTime> <!-- 1094 -->
+          <ID>I003INVOERVERGEU</ID> <!-- CDD-1094 an..70 -->
+          <Name>NAME_HERE</Name> <!-- CDD-1094 ADDED -->
+          <TypeCode>003</TypeCode>
+          <LPCOExemptionCode>123</LPCOExemptionCode> <!-- 1094 -->
+        </AdditionalDocument>
+        <AdditionalDocument>
+          <CategoryCode>N</CategoryCode>
+          <ID>N861UnivCertOrigin</ID>
+          <TypeCode>861</TypeCode>
+        </AdditionalDocument>
+        <AdditionalInformation>
+          <StatementCode>1</StatementCode><!-- not affiliated -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>3</StatementCode><!-- no price influence -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>5</StatementCode><!-- no approximate value -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>8</StatementCode><!-- special restrictions -->
+          <StatementDescription>Special Restrictions</StatementDescription>
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>9</StatementCode><!-- no price conditions -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>11</StatementCode><!-- no royalties or license fees -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>13</StatementCode><!-- no other revenue -->
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>16</StatementCode><!-- customs decisions -->
+          <StatementDescription>11NL12345678901234</StatementDescription>
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>17</StatementCode><!-- contract information -->
+          <StatementDescription>Contract 12123, 24-11-2011</StatementDescription>
+          <StatementTypeCode>ABC</StatementTypeCode>
+        </AdditionalInformation>
+        <AdditionalInformation>
+          <StatementCode>90010</StatementCode>
+          <StatementDescription>VERVOERDER: InterTrans</StatementDescription>
+          <StatementTypeCode>CUS</StatementTypeCode>
+        </AdditionalInformation>
+        <Commodity>
+          <Description>Inertial navigation systems</Description>
+          <Classification>
+            <ID>901420209000000000</ID>
+            <IdentificationTypeCode>SRZ</IdentificationTypeCode>
+          </Classification>
+          <Classification>
+            <ID>9002</ID>
+            <IdentificationTypeCode>GN</IdentificationTypeCode><!--Not representative for this commodity-->
+          </Classification>
+          <DutyTaxFee>
+            <AdValoremTaxBaseAmount currencyID="EUR">900</AdValoremTaxBaseAmount>
+            <DutyRegimeCode>
+              100<!--Specified a Tariff Quota preference (not representative)--></DutyRegimeCode>
+            <TypeCode>B00</TypeCode>
+            <Payment>
+              <MethodCode>M</MethodCode>
+            </Payment>
+          </DutyTaxFee>
+        </Commodity>
+        <GovernmentProcedure>
+          <CurrentCode>40</CurrentCode>
+          <PreviousCode>91</PreviousCode>
+        </GovernmentProcedure>
+        <GovernmentProcedure>
+          <CurrentCode>C30</CurrentCode>
+        </GovernmentProcedure>
+        <Origin>
+          <CountryCode>US</CountryCode>
+        </Origin>
+        <Packaging>
+          <SequenceNumeric>1</SequenceNumeric>
+          <MarksNumbersID>SHIPPING MARKS PART1 SHIPPING</MarksNumbersID>
+          <QuantityQuantity>9</QuantityQuantity>
+          <TypeCode>CT</TypeCode>
+        </Packaging>
+        <PreviousDocument>
+          <ID>X355ID13</ID> <!-- 1094 -->
+          <LineNumeric>1</LineNumeric>
+        </PreviousDocument>
+        <ValuationAdjustment>
+          <AdditionCode>155</AdditionCode>
+        </ValuationAdjustment>
+      </GovernmentAgencyGoodsItem>
+      <Invoice>
+        <ID>INVOICENUMBER</ID>
+        <IssueDateTime>
+          <udt:DateTimeString formatCode="304">20130812091112Z</udt:DateTimeString>
+        </IssueDateTime>    <!-- 1094 -->
+      </Invoice>
+      <Payer>
+        <ID>ZZ123456789003</ID>
+      </Payer>
+      <Seller>
+        <Name>Seller name Part1Sellername Part2</Name>
+        <Address>
+          <CityName>Seller City name</CityName>
+          <CountryCode>MX</CountryCode>
+          <Line>Sellerstreet Part1SellerStreet Part2 7C</Line>
+          <PostcodeID>8603 AV</PostcodeID>
+        </Address>
+      </Seller>
+      <Surety>
+        <ID>ZZ123456789003</ID>
+      </Surety>
+      <TradeTerms>
+        <ConditionCode>CIP</ConditionCode>
+        <CountryRelationshipCode>158</CountryRelationshipCode>
+        <LocationName>Rotterdam</LocationName>
+      </TradeTerms>
+      <UCR>
+        <ID>UN1234567893123456789</ID>
+        <TraderAssignedReferenceID>P198R65Q29</TraderAssignedReferenceID>
+      </UCR>
+      <Warehouse>
+        <ID>A123456ZZ</ID>
+      </Warehouse>
+    </GoodsShipment>
+  </Declaration>
+</md:MetaData>

--- a/test/util/FakeRequests.scala
+++ b/test/util/FakeRequests.scala
@@ -17,7 +17,7 @@
 package util
 
 import play.api.http.HeaderNames.{ACCEPT, AUTHORIZATION}
-import play.api.mvc.{AnyContentAsText, AnyContentAsXml}
+import play.api.mvc.{AnyContentAsRaw, AnyContentAsText, AnyContentAsXml}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{CONTENT_TYPE, POST}
 import util.RequestHeaders._
@@ -28,6 +28,10 @@ object FakeRequests {
   lazy val ValidSubmissionV2Request: FakeRequest[AnyContentAsXml] = FakeRequest()
     .withHeaders(ValidHeadersV2.toSeq: _*)
     .withXmlBody(ValidSubmissionXML)
+
+  lazy val ValidSubmissionRawRequest: FakeRequest[AnyContentAsRaw] = FakeRequest()
+    .withHeaders(ValidHeadersV2.toSeq: _*)
+    .withRawBody(ValidRawXmlByte)
 
   lazy val ValidSubmissionV3Request: FakeRequest[AnyContentAsXml] = FakeRequest()
     .withHeaders(ValidHeadersV3.toSeq: _*)

--- a/test/util/TestData.scala
+++ b/test/util/TestData.scala
@@ -401,6 +401,14 @@ object RequestHeaders {
     X_SUBMITTER_IDENTIFIER_HEADER
   )
 
+  val ValidHeadersV2WithCharset: Map[String, String] = Map(
+    CONTENT_TYPE -> CONTENT_TYPE_CHARSET_VALUE,
+    ACCEPT_HMRC_XML_V2_HEADER,
+    X_CLIENT_ID_HEADER,
+    X_BADGE_IDENTIFIER_HEADER,
+    X_SUBMITTER_IDENTIFIER_HEADER
+  )
+
   val ValidHeadersV3: Map[String, String] = Map(
     CONTENT_TYPE_HEADER,
     ACCEPT_HMRC_XML_V3_HEADER,

--- a/test/util/TestXMLData.scala
+++ b/test/util/TestXMLData.scala
@@ -16,6 +16,10 @@
 
 package util
 
+import java.nio.file.{Files, Paths}
+
+import akka.util.ByteString
+
 import scala.xml.Elem
 
 object TestXMLData {
@@ -608,4 +612,6 @@ object TestXMLData {
     </Files>
   </FileUploadRequest>
 
+  lazy val ValidRawXmlByte: ByteString = ByteString.fromArray(Files.readAllBytes(Paths.get(getClass.getResource("/raw/valid_xml.raw").getPath)))
+  lazy val InvalidRawXmlByte: ByteString = ByteString.fromArray(Files.readAllBytes(Paths.get(getClass.getResource("/raw/invalid_xml.raw").getPath)))
 }


### PR DESCRIPTION
Adding unit tests to check that the submission api specifically rejects xml payloads containing non-utf-8 character bytes.