### PR TITLE
CDD-3415 Fix local perf-tests by increasing buffer size for large requests

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -393,3 +393,5 @@ microservice {
     }
   }
 }
+
+play.http.parser.maxMemoryBuffer=20M


### PR DESCRIPTION
When performance tests are running on localhost, they require to send large requests.

This change will add the default max buffer size for submitting large payload. It does not impact production/qa envs as there is already a configuration which overrides it