### PR TITLE
DCWL-1650 Revert to original error code mapping

### DIFF
--- a/app/uk/gov/hmrc/customs/declaration/services/Utils.scala
+++ b/app/uk/gov/hmrc/customs/declaration/services/Utils.scala
@@ -21,12 +21,11 @@ import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, NOT_ACCEPTABLE, NOT_FOUND, 
 
 object Utils {
   def errorResponseForErrorCode(errorCode: Int): ErrorResponse = errorCode match {
-    case BAD_REQUEST => ErrorResponse.ErrorGenericBadRequest
-    case UNAUTHORIZED => ErrorResponse.ErrorUnauthorized
-    case FORBIDDEN => ErrorResponse.ErrorPayloadForbidden
-    case NOT_FOUND => ErrorResponse.ErrorNotFound
-    case NOT_ACCEPTABLE => ErrorResponse.ErrorInvalidPayload
-    case UNSUPPORTED_MEDIA_TYPE => ErrorResponse.ErrorContentTypeHeaderInvalid
-    case _ => ErrorResponse.ErrorInternalServerError
+    case BAD_REQUEST | UNAUTHORIZED | NOT_FOUND | NOT_ACCEPTABLE | UNSUPPORTED_MEDIA_TYPE =>
+      ErrorResponse.ErrorInternalServerError
+    case FORBIDDEN =>
+      ErrorResponse.ErrorPayloadForbidden
+    case _ =>
+      ErrorResponse.ErrorInternalServerError
   }
 }

--- a/app/uk/gov/hmrc/customs/declaration/services/declarationServices.scala
+++ b/app/uk/gov/hmrc/customs/declaration/services/declarationServices.scala
@@ -132,9 +132,9 @@ trait DeclarationService extends ApiSubscriptionFieldsService {
         logger.error("unhealthy state entered")
         Left(errorResponseServiceUnavailable.XmlResult.withConversationId)
       case e: HttpException =>
-        logger.warn(s"submission declaration call failed with ${e.responseCode}: [${e.getMessage}]")
-        val errorMessage = Utils.errorResponseForErrorCode(e.responseCode)
-        Left(errorMessage.XmlResult.withConversationId)
+        val errorResponse = Utils.errorResponseForErrorCode(e.responseCode)
+        logger.warn(s"submission declaration call failed with ${e.responseCode}, will return with ${errorResponse.httpStatusCode}: [${e.getMessage}]")
+        Left(errorResponse.XmlResult.withConversationId)
       case NonFatal(e) =>
         logger.error(s"submission declaration call failed: [${e.getMessage}]", e)
         Left(ErrorResponse.ErrorInternalServerError.XmlResult.withConversationId)


### PR DESCRIPTION
We don't want to change the mapping of error responses; just to log what we're getting back from EIS.
