### PR TITLE
DCWL-3669: Dependency upgrade to fix the jackson-core vulnerability

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,9 +6,9 @@ object AppDependencies {
 
   val playSuffix = "-play-30"
 
-  val bootstrapVersion = "9.13.0"
-  val hmrcMongoVersion = "2.6.0"
-  val scalamockVersion = "7.2.0"
+  val bootstrapVersion = "9.18.0"
+  val hmrcMongoVersion = "2.7.0"
+  val scalamockVersion = "7.4.0"
 
   val bootstrapBackendPlay30        = "uk.gov.hmrc"        %% s"bootstrap-backend$playSuffix" % bootstrapVersion
   val cats                          = "org.typelevel"      %% "cats-core"                     % "2.13.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.jcenterRepo
 
 addSbtPlugin("uk.gov.hmrc"       %  "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("com.github.sbt"    %  "sbt-release"           % "1.0.15")
-addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.7")
+addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.8")
 addSbtPlugin("uk.gov.hmrc"       %  "sbt-distributables"    % "2.6.0")
 addSbtPlugin("net.virtual-void"  %  "sbt-dependency-graph"  % "0.10.0-RC1")
 addSbtPlugin("org.scoverage"     %  "sbt-scoverage"         % "2.3.0")

--- a/test/unit/model/filetransmission/FileTransmissionModelSpec.scala
+++ b/test/unit/model/filetransmission/FileTransmissionModelSpec.scala
@@ -25,9 +25,9 @@ class FileTransmissionModelSpec extends AnyWordSpecLike with Matchers {
 
   "file transmission model" should {
     "serialise to Json" in {
-      val actual = Json.prettyPrint(Json.toJson(FileTransmissionRequest))
+      val actual = Json.toJson(FileTransmissionRequest)
 
-      actual shouldBe FileTransmissionRequestJsonString
+      actual shouldBe Json.parse(FileTransmissionRequestJsonString)
     }
   }
 }


### PR DESCRIPTION
Please ensure we are following our Ways of Working for Pull Requests: https://confluence.tools.tax.service.gov.uk/display/BTL/Ways+of+Working+for+Pull+Requests