### PR TITLE
DCWL-3127: Removed deprecated retrievals.name from auth actions

### DIFF
--- a/app/uk/gov/hmrc/customs/declaration/model/models.scala
+++ b/app/uk/gov/hmrc/customs/declaration/model/models.scala
@@ -56,7 +56,6 @@ case class NrsRetrievalData(internalId: Option[String],
   confidenceLevel: ConfidenceLevel,
   nino: Option[String],
   saUtr: Option[String],
-  name: Option[Name],
   dateOfBirth: Option[LocalDate],
   email: Option[String],
   agentInformation: AgentInformation,
@@ -72,7 +71,6 @@ case class NrsRetrievalData(internalId: Option[String],
 
 object NrsRetrievalData {
   implicit val credentialsFormat: OFormat[Credentials] = Json.format[Credentials]
-  implicit val nameFormat: OFormat[Name] = Json.format[Name]
   implicit val agentInformationFormat: OFormat[AgentInformation] = Json.format[AgentInformation]
   implicit val mdtpInformationFormat: OFormat[MdtpInformation] = Json.format[MdtpInformation]
   implicit val itmpNameFormat: OFormat[ItmpName] = Json.format[ItmpName]

--- a/app/uk/gov/hmrc/customs/declaration/services/CustomsAuthService.scala
+++ b/app/uk/gov/hmrc/customs/declaration/services/CustomsAuthService.scala
@@ -43,7 +43,7 @@ class CustomsAuthService @Inject()(override val authConnector: AuthConnector,
   private val customsDeclarationEnrolment = "write:customs-declaration"
 
   private type NrsRetrievalDataType = Option[String] ~ Option[String] ~ Option[String] ~ Option[Credentials] ~ ConfidenceLevel ~ Option[String] ~
-    Option[String] ~ Option[Name] ~ Option[LocalDate] ~ Option[String] ~ AgentInformation ~ Option[String] ~
+    Option[String] ~ Option[LocalDate] ~ Option[String] ~ AgentInformation ~ Option[String] ~
     Option[CredentialRole] ~ Option[MdtpInformation] ~ Option[ItmpName] ~ Option[LocalDate] ~ Option[ItmpAddress] ~
     Option[AffinityGroup] ~ Option[String] ~ LoginTimes
 
@@ -52,7 +52,7 @@ class CustomsAuthService @Inject()(override val authConnector: AuthConnector,
   private val cspRetrievals: Retrieval[NrsRetrievalDataType]=
     Retrievals.internalId and Retrievals.externalId and Retrievals.agentCode and
       Retrievals.credentials and Retrievals.confidenceLevel and Retrievals.nino and
-      Retrievals.saUtr and Retrievals.name and Retrievals.dateOfBirth and
+      Retrievals.saUtr and Retrievals.dateOfBirth and
       Retrievals.email and Retrievals.agentInformation and Retrievals.groupIdentifier and
       Retrievals.credentialRole and Retrievals.mdtpInformation and Retrievals.itmpName and
       Retrievals.itmpDateOfBirth and Retrievals.itmpAddress and Retrievals.affinityGroup and
@@ -75,11 +75,11 @@ class CustomsAuthService @Inject()(override val authConnector: AuthConnector,
     val eventualAuth: Future[Either[ErrorResponse, (IsCsp, Option[NrsRetrievalData])]] =
       if (requestRetrievals) {
         authorised(Enrolment(customsDeclarationEnrolment) and AuthProviders(PrivilegedApplication)).retrieve(cspRetrievals) {
-          case internalId ~ externalId ~ agentCode ~ credentials ~ confidenceLevel ~ nino ~ saUtr ~ name ~ dateOfBirth ~ email ~ agentInformation ~ groupIdentifier ~
+          case internalId ~ externalId ~ agentCode ~ credentials ~ confidenceLevel ~ nino ~ saUtr ~ dateOfBirth ~ email ~ agentInformation ~ groupIdentifier ~
             credentialRole ~ mdtpInformation ~ itmpName ~ itmpDateOfBirth ~ itmpAddress ~ affinityGroup ~ credentialStrength ~ loginTimes =>
             Future.successful {
               val retrievalData = NrsRetrievalData(internalId, externalId, agentCode, credentials, confidenceLevel, nino, saUtr,
-                name, dateOfBirth, email, agentInformation, groupIdentifier, credentialRole, mdtpInformation, itmpName,
+                dateOfBirth, email, agentInformation, groupIdentifier, credentialRole, mdtpInformation, itmpName,
                 itmpDateOfBirth, itmpAddress, affinityGroup, credentialStrength, loginTimes)
 
               logger.debug(s"Successfully authorised CSP PrivilegedApplication with $customsDeclarationEnrolment enrolment with retrievals")
@@ -113,11 +113,11 @@ class CustomsAuthService @Inject()(override val authConnector: AuthConnector,
     val eventualAuth: Future[(Enrolments, Option[NrsRetrievalData])] =
       if (requestRetrievals) {
         authorised(Enrolment(hmrcCustomsEnrolment) and AuthProviders(GovernmentGateway)).retrieve(nonCspRetrievals) {
-          case internalId ~ externalId ~ agentCode ~ credentials ~ confidenceLevel ~ nino ~ saUtr ~ name ~ dateOfBirth ~ email ~ agentInformation ~ groupIdentifier ~
+          case internalId ~ externalId ~ agentCode ~ credentials ~ confidenceLevel ~ nino ~ saUtr ~ dateOfBirth ~ email ~ agentInformation ~ groupIdentifier ~
             credentialRole ~ mdtpInformation ~ itmpName ~ itmpDateOfBirth ~ itmpAddress ~ affinityGroup ~ credentialStrength ~ loginTimes ~ authorisedEnrolments =>
 
             val retrievalData = NrsRetrievalData(internalId, externalId, agentCode, credentials, confidenceLevel, nino, saUtr,
-              name, dateOfBirth, email, agentInformation, groupIdentifier, credentialRole, mdtpInformation, itmpName,
+              dateOfBirth, email, agentInformation, groupIdentifier, credentialRole, mdtpInformation, itmpName,
               itmpDateOfBirth, itmpAddress, affinityGroup, credentialStrength, loginTimes)
 
             logger.debug(s"Successfully authorised non-CSP with $hmrcCustomsEnrolment enrolment and GovernmentGateway non-CSP retrievals pending eori check")

--- a/test/unit/connectors/ApiSubscriptionFieldsConnectorSpec.scala
+++ b/test/unit/connectors/ApiSubscriptionFieldsConnectorSpec.scala
@@ -67,7 +67,6 @@ class ApiSubscriptionFieldsConnectorSpec extends AnyWordSpecLike
   private val mockAuditConnector = mock[AuditConnector]
   private implicit val hc: HeaderCarrier = HeaderCarrier()
   private implicit val vpr: ValidatedPayloadRequest[AnyContentAsXml] = TestData.TestCspValidatedPayloadRequest
-  private implicit val ec: ExecutionContext = Helpers.stubControllerComponents().executionContext
 
   override lazy val app: Application = new GuiceApplicationBuilder()
     .configure(

--- a/test/unit/connectors/DeclarationConnectorSpec.scala
+++ b/test/unit/connectors/DeclarationConnectorSpec.scala
@@ -147,7 +147,6 @@ class DeclarationConnectorSpec extends AnyWordSpecLike
   private val httpFormattedDate = "Tue, 04 Jul 2017 13:45:00 UTC"
 
   private val correlationId = UUID.randomUUID()
-  private val successfulHttpResponse = HttpResponse(200, "")
 
   "MdgWcoDeclarationConnector" can {
 

--- a/test/unit/connectors/NrsConnectorSpec.scala
+++ b/test/unit/connectors/NrsConnectorSpec.scala
@@ -51,7 +51,6 @@ import util.TestData.{fileUploadConfig, nrSubmissionId, nrsConfigEnabled}
 import util.ExternalServicesConfig.*
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
 class NrsConnectorSpec extends AnyWordSpecLike

--- a/test/unit/connectors/upscan/UpscanInitiateConnectorSpec.scala
+++ b/test/unit/connectors/upscan/UpscanInitiateConnectorSpec.scala
@@ -49,7 +49,6 @@ import uk.gov.hmrc.play.bootstrap.http.{DefaultHttpAuditing, HttpClientV2Provide
 import util.ExternalServicesConfig.{Host, Port}
 import util.TestData
 import util.TestData.{ValidatedFileUploadPayloadRequestForNonCspWithTwoFiles, fileUploadConfig}
-import util.VerifyLogging.verifyDeclarationsLoggerError
 
 class UpscanInitiateConnectorSpec extends AnyWordSpecLike
   with MockitoSugar

--- a/test/util/AuthConnectorStubbing.scala
+++ b/test/util/AuthConnectorStubbing.scala
@@ -66,7 +66,7 @@ trait AuthConnectorStubbing extends AnyWordSpecLike with GuiceOneAppPerSuite wit
       .thenReturn(Future.failed(authException))
   }
 
-  type NrsDataType = Option[String] ~ Option[String] ~ Option[String] ~ Option[Credentials] ~ ConfidenceLevel ~ Option[String] ~ Option[String] ~ Option[Name] ~ Option[LocalDate] ~ Option[String] ~ AgentInformation ~ Option[String] ~ Option[CredentialRole] ~ Option[MdtpInformation] ~ Option[ItmpName] ~ Option[LocalDate] ~ Option[ItmpAddress] ~ Option[AffinityGroup] ~ Option[String] ~ LoginTimes
+  type NrsDataType = Option[String] ~ Option[String] ~ Option[String] ~ Option[Credentials] ~ ConfidenceLevel ~ Option[String] ~ Option[String] ~ Option[LocalDate] ~ Option[String] ~ AgentInformation ~ Option[String] ~ Option[CredentialRole] ~ Option[MdtpInformation] ~ Option[ItmpName] ~ Option[LocalDate] ~ Option[ItmpAddress] ~ Option[AffinityGroup] ~ Option[String] ~ LoginTimes
   type CspRetrievalDataType = Retrieval[NrsDataType]
   type NrsRetrievalDataTypeWithEnrolments = Retrieval[NrsDataType ~ Enrolments]
 

--- a/test/util/TestData.scala
+++ b/test/util/TestData.scala
@@ -148,7 +148,6 @@ object TestData {
   val nrsConfidenceLevel: ConfidenceLevel.L500.type = L500
   val nrsNinoValue: String = "ninov"
   val nrsSaUtrValue: String = "saUtr"
-  val nrsNameValue: Option[Name] = Some(Name(Some("name"), Some("lastname")))
   val TWENTY_FIVE = 25
   val nrsDateOfBirth: Option[LocalDate] = Some(LocalDate.now().minusYears(TWENTY_FIVE))
   val nrsEmailValue: Option[String] = Some("nrsEmailValue")
@@ -191,7 +190,6 @@ object TestData {
     nrsConfidenceLevel,
     Some(nrsNinoValue),
     Some(nrsSaUtrValue),
-    nrsNameValue,
     nrsDateOfBirth,
     nrsEmailValue,
     nrsAgentInformationValue,
@@ -205,19 +203,18 @@ object TestData {
     nrsCredentialStrength,
     nrsLoginTimes)
 
-  val nrsRetrievalData: Retrieval[Option[String] ~ Option[String] ~ Option[String] ~ Option[Credentials] ~ ConfidenceLevel ~ Option[String] ~ Option[String] ~ Option[Name] ~ Option[LocalDate] ~ Option[String] ~ AgentInformation ~ Option[String] ~ Option[CredentialRole] ~ Option[MdtpInformation] ~ Option[ItmpName] ~ Option[LocalDate] ~ Option[ItmpAddress] ~ Option[AffinityGroup] ~ Option[String] ~ LoginTimes] = Retrievals.internalId and Retrievals.externalId and Retrievals.agentCode and Retrievals.credentials and Retrievals.confidenceLevel and
-    Retrievals.nino and Retrievals.saUtr and Retrievals.name and Retrievals.dateOfBirth and
+  val nrsRetrievalData: Retrieval[Option[String] ~ Option[String] ~ Option[String] ~ Option[Credentials] ~ ConfidenceLevel ~ Option[String] ~ Option[String] ~ Option[LocalDate] ~ Option[String] ~ AgentInformation ~ Option[String] ~ Option[CredentialRole] ~ Option[MdtpInformation] ~ Option[ItmpName] ~ Option[LocalDate] ~ Option[ItmpAddress] ~ Option[AffinityGroup] ~ Option[String] ~ LoginTimes] = Retrievals.internalId and Retrievals.externalId and Retrievals.agentCode and Retrievals.credentials and Retrievals.confidenceLevel and
+    Retrievals.nino and Retrievals.saUtr and Retrievals.dateOfBirth and
     Retrievals.email and Retrievals.agentInformation and Retrievals.groupIdentifier and Retrievals.credentialRole and Retrievals.mdtpInformation and
     Retrievals.itmpName and Retrievals.itmpDateOfBirth and Retrievals.itmpAddress and Retrievals.affinityGroup and Retrievals.credentialStrength and Retrievals.loginTimes
 
-  val nrsReturnData = new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~( new ~(new ~(Some(nrsInternalIdValue)
+  val nrsReturnData = new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~(new ~( new ~(Some(nrsInternalIdValue)
     ,Some(nrsExternalIdValue)),
     Some(nrsAgentCodeValue)),
     nrsCredentials),
     nrsConfidenceLevel),
     Some(nrsNinoValue)),
     Some(nrsSaUtrValue)),
-    nrsNameValue),
     nrsDateOfBirth),
     nrsEmailValue),
     nrsAgentInformationValue),


### PR DESCRIPTION
DCWL-3127: Removed depricated retrival.name from auth actions